### PR TITLE
Fix "Stereo" shown for mono tunes

### DIFF
--- a/public_html/asmadb/asma.js
+++ b/public_html/asmadb/asma.js
@@ -990,6 +990,7 @@ class ASMA {
 			fileInfo.author = "Unknown";
 		}
 		fileInfo.date = asapInfo.getDate();
+		fileInfo.channels = asapInfo.getChannels();
 		fileInfo.fileSize = fileInfo.getContent().length;
 		fileInfo.originalModuleExt = asapInfo.getOriginalModuleExt(fileInfo.getContent(), fileInfo.getContent().length);
 		if (fileInfo.originalModuleExt != null) {


### PR DESCRIPTION
Steps to reproduce:
1. Open the ASMADB page.
2. "Choose Files", select a mono SAP file.

Expected:
2. The "Channels" field shows "Mono (4)".

Actual:
2. The "Channels" field shows "Stereo (8)".